### PR TITLE
Added Mining jobs to the list of features

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This plugin adds:
 * 1 Battlestation
 * 8 Fighters, Drones, and other carried ships (Utility and Combat)
 * A few weapons and outfits.
+* Mining jobs
 
 Requires 0.9.15+/Continuous
 


### PR DESCRIPTION
After installing a whole bunch of Endless Sky Plugins I noticed one of them had added mining jobs cluttering my job board. Since these jobs don't pay much more than just selling the required minerals to the outfitter I wanted to find out how to remove these jobs from the game or increase their payouts, but it was hard to find out what mod even added these jobs in the first place. After I failed to find any information online I checked each mod I had one by one to see if it was the one adding them, until I finally identified this mod as the one I was looking for. It could've saved me a fair bit of time if mining jobs were listed as a feature in Mega-Freight's readme, hence the pull request.

Not to come off too negatively: I really like all the giant ships this plugin adds to the galaxy, so thank you for making it ^^