### PR TITLE
Fix about syntax in plugin.txt

### DIFF
--- a/plugin.txt
+++ b/plugin.txt
@@ -1,8 +1,7 @@
 name "Mega Freight"
 version 1.0.0010101000100100110
-about `Add 162(so far) ships ranging from small freighter to massive container carriers and warships for nearly every faction and more. More stations to exploit the benefit of vacuum and zero-g environment and serve the other purpose than refineries. Ship releases and new station constructions as well as a few background changes to keep universe (somewhat) more alive.
-
-Many of new the freighter are also specialized and may unlock more well-paid jobs as well as larger jobs to fill up larger ships.`
+about `Add 162(so far) ships ranging from small freighter to massive container carriers and warships for nearly every faction and more. More stations to exploit the benefit of vacuum and zero-g environment and serve the other purpose than refineries. Ship releases and new station constructions as well as a few background changes to keep universe (somewhat) more alive.`
+about `Many of new the freighter are also specialized and may unlock more well-paid jobs as well as larger jobs to fill up larger ships.`
 authors
 	1010todd
 tags


### PR DESCRIPTION
The `about` field in `plugin.txt` being multi-line is not a supported syntax.
This causes part of the about to not be visible, alongside the following warnings:
```
Warning: Closing quotation mark is missing:
file "endless-sky/plugins/Mega Freight/plugin.txt"
L3:   about "Add 162(so far) ships ranging from small freighter to massive container carriers and warships for nearly every faction and more. More stations to exploit the benefit of vacuum and zero-g environment and serve the other purpose than refineries. Ship releases and new station constructions as well as a few background changes to keep universe (somewhat) more alive."

Skipping unrecognized attribute:
file "endless-sky/plugins/Mega Freight/plugin.txt"
L5:   Many of new the freighter are also specialized and may unlock more well-paid jobs as well as larger jobs to fill up larger "ships.`"
```

Without this fix:
![image](https://github.com/user-attachments/assets/b67be175-56b3-4af5-8851-884997b78335)


With this fix:
![image](https://github.com/user-attachments/assets/8039ef82-d99e-482c-aa3b-b9034149378a)
